### PR TITLE
Updates to dependencies

### DIFF
--- a/gen/main.go
+++ b/gen/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io"
 	"io/ioutil"
 	"os"
 	"regexp"
@@ -9,97 +8,6 @@ import (
 	"github.com/ipld/go-ipld-prime/schema"
 	gengo "github.com/ipld/go-ipld-prime/schema/gen/go"
 )
-
-type typedNodeGenerator interface {
-
-	// -- the natively-typed apis -->
-	//   (might be more readable to group these in another interface and have it
-	//     return a `typedNodeGenerator` with the rest?  but structurally same.)
-
-	EmitNativeType(io.Writer)
-	EmitNativeAccessors(io.Writer) // depends on the kind -- field accessors for struct, typed iterators for map, etc.
-	EmitNativeBuilder(io.Writer)   // typically emits some kind of struct that has a Build method.
-	EmitNativeMaybe(io.Writer)     // a pointer-free 'maybe' mechanism is generated for all types.
-
-	// -- the schema.TypedNode.Type method and vars -->
-
-	EmitTypedNodeMethodType(io.Writer) // these emit dummies for now
-
-	// -- all node methods -->
-	//   (and note that the nodeBuilder for this one should be the "semantic" one,
-	//     e.g. it *always* acts like a map for structs, even if the repr is different.)
-
-	nodeGenerator
-
-	// -- and the representation and its node and nodebuilder -->
-
-	EmitTypedNodeMethodRepresentation(io.Writer)
-}
-
-type typedLinkNodeGenerator interface {
-	// all methods in typedNodeGenerator
-	typedNodeGenerator
-
-	// as typed.LinkNode.ReferencedNodeBuilder generator
-	EmitTypedLinkNodeMethodReferencedNodeBuilder(io.Writer)
-}
-
-type nodeGenerator interface {
-	EmitNodeType(io.Writer)
-	EmitNodeMethodReprKind(io.Writer)
-	EmitNodeMethodLookupString(io.Writer)
-	EmitNodeMethodLookup(io.Writer)
-	EmitNodeMethodLookupIndex(io.Writer)
-	EmitNodeMethodLookupSegment(io.Writer)
-	EmitNodeMethodMapIterator(io.Writer)  // also iterator itself
-	EmitNodeMethodListIterator(io.Writer) // also iterator itself
-	EmitNodeMethodLength(io.Writer)
-	EmitNodeMethodIsUndefined(io.Writer)
-	EmitNodeMethodIsNull(io.Writer)
-	EmitNodeMethodAsBool(io.Writer)
-	EmitNodeMethodAsInt(io.Writer)
-	EmitNodeMethodAsFloat(io.Writer)
-	EmitNodeMethodAsString(io.Writer)
-	EmitNodeMethodAsBytes(io.Writer)
-	EmitNodeMethodAsLink(io.Writer)
-}
-
-func emitEntireType(ng nodeGenerator, w io.Writer) {
-	if ng == nil {
-		return
-	}
-	ng.EmitNodeType(w)
-	ng.EmitNodeMethodReprKind(w)
-	ng.EmitNodeMethodLookupString(w)
-	ng.EmitNodeMethodLookup(w)
-	ng.EmitNodeMethodLookupIndex(w)
-	ng.EmitNodeMethodLookupSegment(w)
-	ng.EmitNodeMethodMapIterator(w)
-	ng.EmitNodeMethodListIterator(w)
-	ng.EmitNodeMethodLength(w)
-	ng.EmitNodeMethodIsUndefined(w)
-	ng.EmitNodeMethodIsNull(w)
-	ng.EmitNodeMethodAsBool(w)
-	ng.EmitNodeMethodAsInt(w)
-	ng.EmitNodeMethodAsFloat(w)
-	ng.EmitNodeMethodAsString(w)
-	ng.EmitNodeMethodAsBytes(w)
-	ng.EmitNodeMethodAsLink(w)
-
-	tg, ok := ng.(typedNodeGenerator)
-	if ok {
-		tg.EmitNativeType(w)
-		tg.EmitNativeAccessors(w)
-		tg.EmitNativeBuilder(w)
-		tg.EmitNativeMaybe(w)
-		tg.EmitTypedNodeMethodType(w)
-		tg.EmitTypedNodeMethodRepresentation(w)
-	}
-	tlg, ok := ng.(typedLinkNodeGenerator)
-	if ok {
-		tlg.EmitTypedLinkNodeMethodReferencedNodeBuilder(w)
-	}
-}
 
 func main() {
 	openOrPanic := func(filename string) *os.File {
@@ -136,32 +44,23 @@ func main() {
 
 	tRaw := schema.SpawnBytes("RawNode")
 
+	adjCfg := &gengo.AdjunctCfg{}
+
+	pkgName := "dagpb"
+
 	f := openOrPanic("common_gen.go")
-	gengo.EmitMinima("dagpb", f)
+	gengo.EmitInternalEnums(pkgName, f)
 
 	f = openOrPanic("pb_node_gen.go")
-	gengo.EmitFileHeader("dagpb", f)
-	tg := gengo.NewGeneratorForKindString(tString)
-	emitEntireType(tg, f)
-	emitEntireType(tg.GetRepresentationNodeGen(), f)
-	tg = gengo.NewGeneratorForKindInt(tInt)
-	emitEntireType(tg, f)
-	emitEntireType(tg.GetRepresentationNodeGen(), f)
-	tg = gengo.NewGeneratorForKindBytes(tBytes)
-	emitEntireType(tg, f)
-	emitEntireType(tg.GetRepresentationNodeGen(), f)
-	tg = gengo.NewGeneratorForKindLink(tLink)
-	emitEntireType(tg, f)
-	emitEntireType(tg.GetRepresentationNodeGen(), f)
-	tg = gengo.NewGeneratorForKindStruct(tPBLink)
-	emitEntireType(tg, f)
-	emitEntireType(tg.GetRepresentationNodeGen(), f)
-	tg = gengo.NewGeneratorForKindList(tPBLinks)
-	emitEntireType(tg, f)
-	emitEntireType(tg.GetRepresentationNodeGen(), f)
-	tg = gengo.NewGeneratorForKindStruct(tPBNode)
-	emitEntireType(tg, f)
-	emitEntireType(tg.GetRepresentationNodeGen(), f)
+	gengo.EmitFileHeader(pkgName, f)
+	gengo.EmitEntireType(gengo.NewStringReprStringGenerator(pkgName, tString, adjCfg), f)
+	gengo.EmitEntireType(gengo.NewIntReprIntGenerator(pkgName, tInt, adjCfg), f)
+	gengo.EmitEntireType(gengo.NewBytesReprBytesGenerator(pkgName, tBytes, adjCfg), f)
+	gengo.EmitEntireType(gengo.NewLinkReprLinkGenerator(pkgName, tLink, adjCfg), f)
+	gengo.EmitEntireType(gengo.NewStructReprMapGenerator(pkgName, tPBLink, adjCfg), f)
+	gengo.EmitEntireType(gengo.NewListReprListGenerator(pkgName, tPBLinks, adjCfg), f)
+	gengo.EmitEntireType(gengo.NewStructReprMapGenerator(pkgName, tPBNode, adjCfg), f)
+
 	if err := f.Close(); err != nil {
 		panic(err)
 	}
@@ -180,7 +79,5 @@ func main() {
 
 	f = openOrPanic("raw_node_gen.go")
 	gengo.EmitFileHeader("dagpb", f)
-	tg = gengo.NewGeneratorForKindBytes(tRaw)
-	emitEntireType(tg, f)
-	emitEntireType(tg.GetRepresentationNodeGen(), f)
+	gengo.EmitEntireType(gengo.NewBytesReprBytesGenerator(pkgName, tRaw, adjCfg), f)
 }

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/ipfs/go-ipld-format v0.2.0
 	github.com/ipfs/go-merkledag v0.3.1
 	github.com/ipfs/go-unixfs v0.2.4
-	github.com/ipld/go-ipld-prime v0.4.0
+	github.com/ipld/go-ipld-prime v0.5.0
 	github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c
 	github.com/multiformats/go-multihash v0.0.13
 	github.com/warpfork/go-wish v0.0.0-20200122115046-b9ea61034e4a

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/ipfs/go-ipld-format v0.2.0
 	github.com/ipfs/go-merkledag v0.3.1
 	github.com/ipfs/go-unixfs v0.2.4
-	github.com/ipld/go-ipld-prime v0.0.2-0.20200428162820-8b59dc292b8e
+	github.com/ipld/go-ipld-prime v0.4.0
 	github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c
 	github.com/multiformats/go-multihash v0.0.13
 	github.com/warpfork/go-wish v0.0.0-20200122115046-b9ea61034e4a

--- a/go.sum
+++ b/go.sum
@@ -154,6 +154,8 @@ github.com/ipfs/go-verifcid v0.0.1 h1:m2HI7zIuR5TFyQ1b79Da5N9dnnCP1vcu2QqawmWlK2
 github.com/ipfs/go-verifcid v0.0.1/go.mod h1:5Hrva5KBeIog4A+UpqlaIU+DEstipcJYQQZc0g37pY0=
 github.com/ipld/go-ipld-prime v0.0.2-0.20200428162820-8b59dc292b8e h1:ZISbJlM0urTANR9KRfRaqlBmyOj5uUtxs2r4Up9IXsA=
 github.com/ipld/go-ipld-prime v0.0.2-0.20200428162820-8b59dc292b8e/go.mod h1:uVIwe/u0H4VdKv3kaN1ck7uCb6yD9cFLS9/ELyXbsw8=
+github.com/ipld/go-ipld-prime v0.4.0 h1:ySDtWeWl+TDMokXlwGANSMeD5TN618cZp9NnxqZ452M=
+github.com/ipld/go-ipld-prime v0.4.0/go.mod h1:uVIwe/u0H4VdKv3kaN1ck7uCb6yD9cFLS9/ELyXbsw8=
 github.com/jackpal/gateway v1.0.5 h1:qzXWUJfuMdlLMtt0a3Dgt+xkWQiA5itDEITVJtuSwMc=
 github.com/jackpal/gateway v1.0.5/go.mod h1:lTpwd4ACLXmpyiCTRtfiNyVnUmqT9RivzCDQetPfnjA=
 github.com/jackpal/go-nat-pmp v1.0.1 h1:i0LektDkO1QlrTm/cSuP+PyBCDnYvjPLGl4LdWEMiaA=

--- a/go.sum
+++ b/go.sum
@@ -156,6 +156,8 @@ github.com/ipld/go-ipld-prime v0.0.2-0.20200428162820-8b59dc292b8e h1:ZISbJlM0ur
 github.com/ipld/go-ipld-prime v0.0.2-0.20200428162820-8b59dc292b8e/go.mod h1:uVIwe/u0H4VdKv3kaN1ck7uCb6yD9cFLS9/ELyXbsw8=
 github.com/ipld/go-ipld-prime v0.4.0 h1:ySDtWeWl+TDMokXlwGANSMeD5TN618cZp9NnxqZ452M=
 github.com/ipld/go-ipld-prime v0.4.0/go.mod h1:uVIwe/u0H4VdKv3kaN1ck7uCb6yD9cFLS9/ELyXbsw8=
+github.com/ipld/go-ipld-prime v0.5.0 h1:kr3nB6/JcFpc3Yj7vveXYuiVyZJzWUkJyLMjQbnoswE=
+github.com/ipld/go-ipld-prime v0.5.0/go.mod h1:uVIwe/u0H4VdKv3kaN1ck7uCb6yD9cFLS9/ELyXbsw8=
 github.com/jackpal/gateway v1.0.5 h1:qzXWUJfuMdlLMtt0a3Dgt+xkWQiA5itDEITVJtuSwMc=
 github.com/jackpal/gateway v1.0.5/go.mod h1:lTpwd4ACLXmpyiCTRtfiNyVnUmqT9RivzCDQetPfnjA=
 github.com/jackpal/go-nat-pmp v1.0.1 h1:i0LektDkO1QlrTm/cSuP+PyBCDnYvjPLGl4LdWEMiaA=

--- a/node_builder_chooser.go
+++ b/node_builder_chooser.go
@@ -8,17 +8,17 @@ import (
 
 // AddDagPBSupportToChooser takes an existing NodeBuilderChooser and subs in
 // Protobuf and Raw node builders where neccesary
-func AddDagPBSupportToChooser(existing traversal.LinkTargetNodeStyleChooser) traversal.LinkTargetNodeStyleChooser {
-	return func(lnk ipld.Link, lnkCtx ipld.LinkContext) (ipld.NodeStyle, error) {
+func AddDagPBSupportToChooser(existing traversal.LinkTargetNodePrototypeChooser) traversal.LinkTargetNodePrototypeChooser {
+	return func(lnk ipld.Link, lnkCtx ipld.LinkContext) (ipld.NodePrototype, error) {
 		c, ok := lnk.(cidlink.Link)
 		if !ok {
 			return existing(lnk, lnkCtx)
 		}
 		switch c.Cid.Prefix().Codec {
 		case 0x70:
-			return _PBNode__NodeStyle{}, nil
+			return _PBNode__NodePrototype{}, nil
 		case 0x55:
-			return _RawNode__NodeStyle{}, nil
+			return _RawNode__NodePrototype{}, nil
 		default:
 			return existing(lnk, lnkCtx)
 		}

--- a/node_builder_chooser_test.go
+++ b/node_builder_chooser_test.go
@@ -15,12 +15,12 @@ import (
 )
 
 func TestNodeBuilderChooser(t *testing.T) {
-	nb1 := basicnode.Style__Any{}
-	nb2 := basicnode.Style__String{}
-	var nb1Chooser traversal.LinkTargetNodeStyleChooser = dagpb.AddDagPBSupportToChooser(func(ipld.Link, ipld.LinkContext) (ipld.NodeStyle, error) {
+	nb1 := basicnode.Prototype.Any
+	nb2 := basicnode.Prototype.String
+	var nb1Chooser traversal.LinkTargetNodePrototypeChooser = dagpb.AddDagPBSupportToChooser(func(ipld.Link, ipld.LinkContext) (ipld.NodePrototype, error) {
 		return nb1, nil
 	})
-	var nb2Chooser traversal.LinkTargetNodeStyleChooser = dagpb.AddDagPBSupportToChooser(func(ipld.Link, ipld.LinkContext) (ipld.NodeStyle, error) {
+	var nb2Chooser traversal.LinkTargetNodePrototypeChooser = dagpb.AddDagPBSupportToChooser(func(ipld.Link, ipld.LinkContext) (ipld.NodePrototype, error) {
 		return nb2, nil
 	})
 	bytes := randomBytes(256)

--- a/nodestyles.go
+++ b/nodestyles.go
@@ -7,14 +7,14 @@ import (
 var Style style
 
 type style struct {
-	Protobuf _PBNode__NodeStyle
-	Raw      _RawNode__NodeStyle
+	Protobuf _PBNode__NodePrototype
+	Raw      _RawNode__NodePrototype
 }
 
-type _PBNode__NodeStyle struct {
+type _PBNode__NodePrototype struct {
 }
 
-func (ns _PBNode__NodeStyle) NewBuilder() ipld.NodeBuilder {
+func (ns _PBNode__NodePrototype) NewBuilder() ipld.NodeBuilder {
 	var nd PBNode
 	return &_PBNode__NodeBuilder{_PBNode__NodeAssembler{nd: &nd}}
 }
@@ -76,50 +76,50 @@ func (na *_PBNode__NodeAssembler) AssignNode(_ ipld.Node) error {
 	panic("not implemented")
 }
 
-func (na *_PBNode__NodeAssembler) Style() ipld.NodeStyle {
-	return _PBNode__NodeStyle{}
+func (na *_PBNode__NodeAssembler) Prototype() ipld.NodePrototype {
+	return _PBNode__NodePrototype{}
 }
 
-func (nd PBNode) Style() ipld.NodeStyle {
-	return _PBNode__NodeStyle{}
+func (nd PBNode) Prototype() ipld.NodePrototype {
+	return _PBNode__NodePrototype{}
 }
 
-func (nd _PBNode__Repr) Style() ipld.NodeStyle {
+func (nd _PBNode__Repr) Prototype() ipld.NodePrototype {
 	return nil
 }
 
-func (nd PBLinks) Style() ipld.NodeStyle {
+func (nd PBLinks) Prototype() ipld.NodePrototype {
 	return nil
 }
 
-func (nd PBLink) Style() ipld.NodeStyle {
+func (nd PBLink) Prototype() ipld.NodePrototype {
 	return nil
 }
 
-func (nd _PBLink__Repr) Style() ipld.NodeStyle {
+func (nd _PBLink__Repr) Prototype() ipld.NodePrototype {
 	return nil
 }
 
-func (nb Link) Style() ipld.NodeStyle {
+func (nb Link) Prototype() ipld.NodePrototype {
 	return nil
 }
 
-func (nb Bytes) Style() ipld.NodeStyle {
+func (nb Bytes) Prototype() ipld.NodePrototype {
 	return nil
 }
 
-func (nb Int) Style() ipld.NodeStyle {
+func (nb Int) Prototype() ipld.NodePrototype {
 	return nil
 }
 
-func (nb String) Style() ipld.NodeStyle {
+func (nb String) Prototype() ipld.NodePrototype {
 	return nil
 }
 
-type _RawNode__NodeStyle struct {
+type _RawNode__NodePrototype struct {
 }
 
-func (ns _RawNode__NodeStyle) NewBuilder() ipld.NodeBuilder {
+func (ns _RawNode__NodePrototype) NewBuilder() ipld.NodeBuilder {
 	var nd RawNode
 	return &_RawNode__NodeBuilder{_RawNode__NodeAssembler{nd: &nd}}
 }
@@ -182,10 +182,10 @@ func (na *_RawNode__NodeAssembler) AssignNode(_ ipld.Node) error {
 	panic("not implemented")
 }
 
-func (na *_RawNode__NodeAssembler) Style() ipld.NodeStyle {
-	return _RawNode__NodeStyle{}
+func (na *_RawNode__NodeAssembler) Prototype() ipld.NodePrototype {
+	return _RawNode__NodePrototype{}
 }
 
-func (nd RawNode) Style() ipld.NodeStyle {
-	return _RawNode__NodeStyle{}
+func (nd RawNode) Prototype() ipld.NodePrototype {
+	return _RawNode__NodePrototype{}
 }

--- a/pb_node_gen.go
+++ b/pb_node_gen.go
@@ -13,17 +13,17 @@ var _ schema.TypedNode = String{}
 func (String) ReprKind() ipld.ReprKind {
 	return ipld.ReprKind_String
 }
-func (String) LookupString(string) (ipld.Node, error) {
-	return nil, ipld.ErrWrongKind{TypeName: "String", MethodName: "LookupString", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_String}
+func (String) LookupByString(string) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "String", MethodName: "LookupByString", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_String}
 }
-func (String) Lookup(ipld.Node) (ipld.Node, error) {
+func (String) LookupByNode(ipld.Node) (ipld.Node, error) {
 	return nil, ipld.ErrWrongKind{TypeName: "String", MethodName: "Lookup", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_String}
 }
-func (String) LookupIndex(idx int) (ipld.Node, error) {
-	return nil, ipld.ErrWrongKind{TypeName: "String", MethodName: "LookupIndex", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_String}
+func (String) LookupByIndex(idx int) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "String", MethodName: "LookupByIndex", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_String}
 }
-func (String) LookupSegment(seg ipld.PathSegment) (ipld.Node, error) {
-	return nil, ipld.ErrWrongKind{TypeName: "String", MethodName: "LookupSegment", AppropriateKind: ipld.ReprKindSet_Recursive, ActualKind: ipld.ReprKind_String}
+func (String) LookupBySegment(seg ipld.PathSegment) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "String", MethodName: "LookupBySegment", AppropriateKind: ipld.ReprKindSet_Recursive, ActualKind: ipld.ReprKind_String}
 }
 func (String) MapIterator() ipld.MapIterator {
 	return mapIteratorReject{ipld.ErrWrongKind{TypeName: "String", MethodName: "MapIterator", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_String}}
@@ -34,7 +34,7 @@ func (String) ListIterator() ipld.ListIterator {
 func (String) Length() int {
 	return -1
 }
-func (String) IsUndefined() bool {
+func (String) IsAbsent() bool {
 	return false
 }
 func (String) IsNull() bool {
@@ -110,17 +110,17 @@ var _ schema.TypedNode = Int{}
 func (Int) ReprKind() ipld.ReprKind {
 	return ipld.ReprKind_Int
 }
-func (Int) LookupString(string) (ipld.Node, error) {
-	return nil, ipld.ErrWrongKind{TypeName: "Int", MethodName: "LookupString", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_Int}
+func (Int) LookupByString(string) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Int", MethodName: "LookupByString", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_Int}
 }
-func (Int) Lookup(ipld.Node) (ipld.Node, error) {
+func (Int) LookupByNode(ipld.Node) (ipld.Node, error) {
 	return nil, ipld.ErrWrongKind{TypeName: "Int", MethodName: "Lookup", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_Int}
 }
-func (Int) LookupIndex(idx int) (ipld.Node, error) {
-	return nil, ipld.ErrWrongKind{TypeName: "Int", MethodName: "LookupIndex", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_Int}
+func (Int) LookupByIndex(idx int) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Int", MethodName: "LookupByIndex", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_Int}
 }
-func (Int) LookupSegment(seg ipld.PathSegment) (ipld.Node, error) {
-	return nil, ipld.ErrWrongKind{TypeName: "Int", MethodName: "LookupSegment", AppropriateKind: ipld.ReprKindSet_Recursive, ActualKind: ipld.ReprKind_Int}
+func (Int) LookupBySegment(seg ipld.PathSegment) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Int", MethodName: "LookupBySegment", AppropriateKind: ipld.ReprKindSet_Recursive, ActualKind: ipld.ReprKind_Int}
 }
 func (Int) MapIterator() ipld.MapIterator {
 	return mapIteratorReject{ipld.ErrWrongKind{TypeName: "Int", MethodName: "MapIterator", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_Int}}
@@ -131,7 +131,7 @@ func (Int) ListIterator() ipld.ListIterator {
 func (Int) Length() int {
 	return -1
 }
-func (Int) IsUndefined() bool {
+func (Int) IsAbsent() bool {
 	return false
 }
 func (Int) IsNull() bool {
@@ -188,17 +188,17 @@ var _ schema.TypedNode = Bytes{}
 func (Bytes) ReprKind() ipld.ReprKind {
 	return ipld.ReprKind_Bytes
 }
-func (Bytes) LookupString(string) (ipld.Node, error) {
-	return nil, ipld.ErrWrongKind{TypeName: "Bytes", MethodName: "LookupString", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_Bytes}
+func (Bytes) LookupByString(string) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Bytes", MethodName: "LookupByString", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_Bytes}
 }
-func (Bytes) Lookup(ipld.Node) (ipld.Node, error) {
+func (Bytes) LookupByNode(ipld.Node) (ipld.Node, error) {
 	return nil, ipld.ErrWrongKind{TypeName: "Bytes", MethodName: "Lookup", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_Bytes}
 }
-func (Bytes) LookupIndex(idx int) (ipld.Node, error) {
-	return nil, ipld.ErrWrongKind{TypeName: "Bytes", MethodName: "LookupIndex", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_Bytes}
+func (Bytes) LookupByIndex(idx int) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Bytes", MethodName: "LookupByIndex", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_Bytes}
 }
-func (Bytes) LookupSegment(seg ipld.PathSegment) (ipld.Node, error) {
-	return nil, ipld.ErrWrongKind{TypeName: "Bytes", MethodName: "LookupSegment", AppropriateKind: ipld.ReprKindSet_Recursive, ActualKind: ipld.ReprKind_Bytes}
+func (Bytes) LookupBySegment(seg ipld.PathSegment) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Bytes", MethodName: "LookupBySegment", AppropriateKind: ipld.ReprKindSet_Recursive, ActualKind: ipld.ReprKind_Bytes}
 }
 func (Bytes) MapIterator() ipld.MapIterator {
 	return mapIteratorReject{ipld.ErrWrongKind{TypeName: "Bytes", MethodName: "MapIterator", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_Bytes}}
@@ -209,7 +209,7 @@ func (Bytes) ListIterator() ipld.ListIterator {
 func (Bytes) Length() int {
 	return -1
 }
-func (Bytes) IsUndefined() bool {
+func (Bytes) IsAbsent() bool {
 	return false
 }
 func (Bytes) IsNull() bool {
@@ -263,17 +263,17 @@ var _ schema.TypedNode = Link{}
 func (Link) ReprKind() ipld.ReprKind {
 	return ipld.ReprKind_Link
 }
-func (Link) LookupString(string) (ipld.Node, error) {
-	return nil, ipld.ErrWrongKind{TypeName: "Link", MethodName: "LookupString", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_Link}
+func (Link) LookupByString(string) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Link", MethodName: "LookupByString", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_Link}
 }
-func (Link) Lookup(ipld.Node) (ipld.Node, error) {
+func (Link) LookupByNode(ipld.Node) (ipld.Node, error) {
 	return nil, ipld.ErrWrongKind{TypeName: "Link", MethodName: "Lookup", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_Link}
 }
-func (Link) LookupIndex(idx int) (ipld.Node, error) {
-	return nil, ipld.ErrWrongKind{TypeName: "Link", MethodName: "LookupIndex", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_Link}
+func (Link) LookupByIndex(idx int) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Link", MethodName: "LookupByIndex", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_Link}
 }
-func (Link) LookupSegment(seg ipld.PathSegment) (ipld.Node, error) {
-	return nil, ipld.ErrWrongKind{TypeName: "Link", MethodName: "LookupSegment", AppropriateKind: ipld.ReprKindSet_Recursive, ActualKind: ipld.ReprKind_Link}
+func (Link) LookupBySegment(seg ipld.PathSegment) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Link", MethodName: "LookupBySegment", AppropriateKind: ipld.ReprKindSet_Recursive, ActualKind: ipld.ReprKind_Link}
 }
 func (Link) MapIterator() ipld.MapIterator {
 	return mapIteratorReject{ipld.ErrWrongKind{TypeName: "Link", MethodName: "MapIterator", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_Link}}
@@ -284,7 +284,7 @@ func (Link) ListIterator() ipld.ListIterator {
 func (Link) Length() int {
 	return -1
 }
-func (Link) IsUndefined() bool {
+func (Link) IsAbsent() bool {
 	return false
 }
 func (Link) IsNull() bool {
@@ -338,39 +338,39 @@ var _ schema.TypedNode = PBLink{}
 func (PBLink) ReprKind() ipld.ReprKind {
 	return ipld.ReprKind_Map
 }
-func (x PBLink) LookupString(key string) (ipld.Node, error) {
+func (x PBLink) LookupByString(key string) (ipld.Node, error) {
 	switch key {
 	case "Hash":
 		if x.d.Hash.Maybe == schema.Maybe_Absent {
-			return ipld.Undef, nil
+			return ipld.Absent, nil
 		}
 		return x.d.Hash.Value, nil
 	case "Name":
 		if x.d.Name.Maybe == schema.Maybe_Absent {
-			return ipld.Undef, nil
+			return ipld.Absent, nil
 		}
 		return x.d.Name.Value, nil
 	case "Tsize":
 		if x.d.Tsize.Maybe == schema.Maybe_Absent {
-			return ipld.Undef, nil
+			return ipld.Absent, nil
 		}
 		return x.d.Tsize.Value, nil
 	default:
 		return nil, schema.ErrNoSuchField{Type: nil /*TODO*/, FieldName: key}
 	}
 }
-func (x PBLink) Lookup(key ipld.Node) (ipld.Node, error) {
+func (x PBLink) LookupByNode(key ipld.Node) (ipld.Node, error) {
 	ks, err := key.AsString()
 	if err != nil {
 		return nil, err
 	}
-	return x.LookupString(ks)
+	return x.LookupByString(ks)
 }
-func (PBLink) LookupIndex(idx int) (ipld.Node, error) {
-	return nil, ipld.ErrWrongKind{TypeName: "PBLink", MethodName: "LookupIndex", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_Map}
+func (PBLink) LookupByIndex(idx int) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "PBLink", MethodName: "LookupByIndex", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_Map}
 }
-func (n PBLink) LookupSegment(seg ipld.PathSegment) (ipld.Node, error) {
-	return n.LookupString(seg.String())
+func (n PBLink) LookupBySegment(seg ipld.PathSegment) (ipld.Node, error) {
+	return n.LookupByString(seg.String())
 }
 func (x PBLink) MapIterator() ipld.MapIterator {
 	return &_PBLink__Itr{&x, 0}
@@ -389,21 +389,21 @@ func (itr *_PBLink__Itr) Next() (k ipld.Node, v ipld.Node, _ error) {
 	case 0:
 		k = String{"Hash"}
 		if itr.node.d.Hash.Maybe == schema.Maybe_Absent {
-			v = ipld.Undef
+			v = ipld.Absent
 			break
 		}
 		v = itr.node.d.Hash.Value
 	case 1:
 		k = String{"Name"}
 		if itr.node.d.Name.Maybe == schema.Maybe_Absent {
-			v = ipld.Undef
+			v = ipld.Absent
 			break
 		}
 		v = itr.node.d.Name.Value
 	case 2:
 		k = String{"Tsize"}
 		if itr.node.d.Tsize.Maybe == schema.Maybe_Absent {
-			v = ipld.Undef
+			v = ipld.Absent
 			break
 		}
 		v = itr.node.d.Tsize.Value
@@ -423,7 +423,7 @@ func (PBLink) ListIterator() ipld.ListIterator {
 func (PBLink) Length() int {
 	return 3
 }
-func (PBLink) IsUndefined() bool {
+func (PBLink) IsAbsent() bool {
 	return false
 }
 func (PBLink) IsNull() bool {
@@ -510,39 +510,39 @@ type _PBLink__Repr struct {
 func (_PBLink__Repr) ReprKind() ipld.ReprKind {
 	return ipld.ReprKind_Map
 }
-func (rn _PBLink__Repr) LookupString(key string) (ipld.Node, error) {
+func (rn _PBLink__Repr) LookupByString(key string) (ipld.Node, error) {
 	switch key {
 	case "Hash":
 		if rn.n.d.Hash.Maybe == schema.Maybe_Absent {
-			return ipld.Undef, ipld.ErrNotExists{ipld.PathSegmentOfString(key)}
+			return ipld.Absent, ipld.ErrNotExists{ipld.PathSegmentOfString(key)}
 		}
 		return rn.n.d.Hash.Value, nil
 	case "Name":
 		if rn.n.d.Name.Maybe == schema.Maybe_Absent {
-			return ipld.Undef, ipld.ErrNotExists{ipld.PathSegmentOfString(key)}
+			return ipld.Absent, ipld.ErrNotExists{ipld.PathSegmentOfString(key)}
 		}
 		return rn.n.d.Name.Value, nil
 	case "Tsize":
 		if rn.n.d.Tsize.Maybe == schema.Maybe_Absent {
-			return ipld.Undef, ipld.ErrNotExists{ipld.PathSegmentOfString(key)}
+			return ipld.Absent, ipld.ErrNotExists{ipld.PathSegmentOfString(key)}
 		}
 		return rn.n.d.Tsize.Value, nil
 	default:
 		return nil, schema.ErrNoSuchField{Type: nil /*TODO*/, FieldName: key}
 	}
 }
-func (rn _PBLink__Repr) Lookup(key ipld.Node) (ipld.Node, error) {
+func (rn _PBLink__Repr) LookupByNode(key ipld.Node) (ipld.Node, error) {
 	ks, err := key.AsString()
 	if err != nil {
 		return nil, err
 	}
-	return rn.LookupString(ks)
+	return rn.LookupByString(ks)
 }
-func (_PBLink__Repr) LookupIndex(idx int) (ipld.Node, error) {
-	return nil, ipld.ErrWrongKind{TypeName: "PBLink.Representation", MethodName: "LookupIndex", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_Map}
+func (_PBLink__Repr) LookupByIndex(idx int) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "PBLink.Representation", MethodName: "LookupByIndex", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_Map}
 }
-func (n _PBLink__Repr) LookupSegment(seg ipld.PathSegment) (ipld.Node, error) {
-	return n.LookupString(seg.String())
+func (n _PBLink__Repr) LookupBySegment(seg ipld.PathSegment) (ipld.Node, error) {
+	return n.LookupByString(seg.String())
 }
 func (rn _PBLink__Repr) MapIterator() ipld.MapIterator {
 	return &_PBLink__ReprItr{rn.n, 0}
@@ -607,7 +607,7 @@ func (rn _PBLink__Repr) Length() int {
 	}
 	return l
 }
-func (_PBLink__Repr) IsUndefined() bool {
+func (_PBLink__Repr) IsAbsent() bool {
 	return false
 }
 func (_PBLink__Repr) IsNull() bool {
@@ -638,28 +638,28 @@ var _ schema.TypedNode = PBLinks{}
 func (PBLinks) ReprKind() ipld.ReprKind {
 	return ipld.ReprKind_List
 }
-func (PBLinks) LookupString(string) (ipld.Node, error) {
-	return nil, ipld.ErrWrongKind{TypeName: "PBLinks", MethodName: "LookupString", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_List}
+func (PBLinks) LookupByString(string) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "PBLinks", MethodName: "LookupByString", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_List}
 }
-func (x PBLinks) Lookup(key ipld.Node) (ipld.Node, error) {
+func (x PBLinks) LookupByNode(key ipld.Node) (ipld.Node, error) {
 	ki, err := key.AsInt()
 	if err != nil {
 		return nil, err
 	}
-	return x.LookupIndex(ki)
+	return x.LookupByIndex(ki)
 }
-func (x PBLinks) LookupIndex(index int) (ipld.Node, error) {
+func (x PBLinks) LookupByIndex(index int) (ipld.Node, error) {
 	if index >= len(x.x) {
 		return nil, ipld.ErrNotExists{ipld.PathSegmentOfInt(index)}
 	}
 	return x.x[index], nil
 }
-func (n PBLinks) LookupSegment(seg ipld.PathSegment) (ipld.Node, error) {
+func (n PBLinks) LookupBySegment(seg ipld.PathSegment) (ipld.Node, error) {
 	idx, err := seg.Index()
 	if err != nil {
 		return nil, err
 	}
-	return n.LookupIndex(idx)
+	return n.LookupByIndex(idx)
 }
 func (PBLinks) MapIterator() ipld.MapIterator {
 	return mapIteratorReject{ipld.ErrWrongKind{TypeName: "PBLinks", MethodName: "MapIterator", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_List}}
@@ -690,7 +690,7 @@ func (itr *_PBLinks__Itr) Done() bool {
 func (x PBLinks) Length() int {
 	return len(x.x)
 }
-func (PBLinks) IsUndefined() bool {
+func (PBLinks) IsAbsent() bool {
 	return false
 }
 func (PBLinks) IsNull() bool {
@@ -746,7 +746,7 @@ var _ schema.TypedNode = PBNode{}
 func (PBNode) ReprKind() ipld.ReprKind {
 	return ipld.ReprKind_Map
 }
-func (x PBNode) LookupString(key string) (ipld.Node, error) {
+func (x PBNode) LookupByString(key string) (ipld.Node, error) {
 	switch key {
 	case "Links":
 		return x.d.Links, nil
@@ -756,18 +756,18 @@ func (x PBNode) LookupString(key string) (ipld.Node, error) {
 		return nil, schema.ErrNoSuchField{Type: nil /*TODO*/, FieldName: key}
 	}
 }
-func (x PBNode) Lookup(key ipld.Node) (ipld.Node, error) {
+func (x PBNode) LookupByNode(key ipld.Node) (ipld.Node, error) {
 	ks, err := key.AsString()
 	if err != nil {
 		return nil, err
 	}
-	return x.LookupString(ks)
+	return x.LookupByString(ks)
 }
-func (PBNode) LookupIndex(idx int) (ipld.Node, error) {
-	return nil, ipld.ErrWrongKind{TypeName: "PBNode", MethodName: "LookupIndex", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_Map}
+func (PBNode) LookupByIndex(idx int) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "PBNode", MethodName: "LookupByIndex", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_Map}
 }
-func (n PBNode) LookupSegment(seg ipld.PathSegment) (ipld.Node, error) {
-	return n.LookupString(seg.String())
+func (n PBNode) LookupBySegment(seg ipld.PathSegment) (ipld.Node, error) {
+	return n.LookupByString(seg.String())
 }
 func (x PBNode) MapIterator() ipld.MapIterator {
 	return &_PBNode__Itr{&x, 0}
@@ -805,7 +805,7 @@ func (PBNode) ListIterator() ipld.ListIterator {
 func (PBNode) Length() int {
 	return 2
 }
-func (PBNode) IsUndefined() bool {
+func (PBNode) IsAbsent() bool {
 	return false
 }
 func (PBNode) IsNull() bool {
@@ -888,7 +888,7 @@ type _PBNode__Repr struct {
 func (_PBNode__Repr) ReprKind() ipld.ReprKind {
 	return ipld.ReprKind_Map
 }
-func (rn _PBNode__Repr) LookupString(key string) (ipld.Node, error) {
+func (rn _PBNode__Repr) LookupByString(key string) (ipld.Node, error) {
 	switch key {
 	case "Links":
 		return rn.n.d.Links, nil
@@ -898,18 +898,18 @@ func (rn _PBNode__Repr) LookupString(key string) (ipld.Node, error) {
 		return nil, schema.ErrNoSuchField{Type: nil /*TODO*/, FieldName: key}
 	}
 }
-func (rn _PBNode__Repr) Lookup(key ipld.Node) (ipld.Node, error) {
+func (rn _PBNode__Repr) LookupByNode(key ipld.Node) (ipld.Node, error) {
 	ks, err := key.AsString()
 	if err != nil {
 		return nil, err
 	}
-	return rn.LookupString(ks)
+	return rn.LookupByString(ks)
 }
-func (_PBNode__Repr) LookupIndex(idx int) (ipld.Node, error) {
-	return nil, ipld.ErrWrongKind{TypeName: "PBNode.Representation", MethodName: "LookupIndex", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_Map}
+func (_PBNode__Repr) LookupByIndex(idx int) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "PBNode.Representation", MethodName: "LookupByIndex", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_Map}
 }
-func (n _PBNode__Repr) LookupSegment(seg ipld.PathSegment) (ipld.Node, error) {
-	return n.LookupString(seg.String())
+func (n _PBNode__Repr) LookupBySegment(seg ipld.PathSegment) (ipld.Node, error) {
+	return n.LookupByString(seg.String())
 }
 func (rn _PBNode__Repr) MapIterator() ipld.MapIterator {
 	return &_PBNode__ReprItr{rn.n, 0}
@@ -950,7 +950,7 @@ func (rn _PBNode__Repr) Length() int {
 	l := 2
 	return l
 }
-func (_PBNode__Repr) IsUndefined() bool {
+func (_PBNode__Repr) IsAbsent() bool {
 	return false
 }
 func (_PBNode__Repr) IsNull() bool {

--- a/raw_node_gen.go
+++ b/raw_node_gen.go
@@ -13,17 +13,17 @@ var _ schema.TypedNode = RawNode{}
 func (RawNode) ReprKind() ipld.ReprKind {
 	return ipld.ReprKind_Bytes
 }
-func (RawNode) LookupString(string) (ipld.Node, error) {
-	return nil, ipld.ErrWrongKind{TypeName: "RawNode", MethodName: "LookupString", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_Bytes}
+func (RawNode) LookupByString(string) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "RawNode", MethodName: "LookupByString", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_Bytes}
 }
-func (RawNode) Lookup(ipld.Node) (ipld.Node, error) {
+func (RawNode) LookupByNode(ipld.Node) (ipld.Node, error) {
 	return nil, ipld.ErrWrongKind{TypeName: "RawNode", MethodName: "Lookup", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_Bytes}
 }
-func (RawNode) LookupIndex(idx int) (ipld.Node, error) {
-	return nil, ipld.ErrWrongKind{TypeName: "RawNode", MethodName: "LookupIndex", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_Bytes}
+func (RawNode) LookupByIndex(idx int) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "RawNode", MethodName: "LookupByIndex", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_Bytes}
 }
-func (RawNode) LookupSegment(seg ipld.PathSegment) (ipld.Node, error) {
-	return nil, ipld.ErrWrongKind{TypeName: "RawNode", MethodName: "LookupSegment", AppropriateKind: ipld.ReprKindSet_Recursive, ActualKind: ipld.ReprKind_Bytes}
+func (RawNode) LookupBySegment(seg ipld.PathSegment) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "RawNode", MethodName: "LookupBySegment", AppropriateKind: ipld.ReprKindSet_Recursive, ActualKind: ipld.ReprKind_Bytes}
 }
 func (RawNode) MapIterator() ipld.MapIterator {
 	return mapIteratorReject{ipld.ErrWrongKind{TypeName: "RawNode", MethodName: "MapIterator", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_Bytes}}
@@ -34,7 +34,7 @@ func (RawNode) ListIterator() ipld.ListIterator {
 func (RawNode) Length() int {
 	return -1
 }
-func (RawNode) IsUndefined() bool {
+func (RawNode) IsAbsent() bool {
 	return false
 }
 func (RawNode) IsNull() bool {

--- a/unixfs_test.go
+++ b/unixfs_test.go
@@ -139,23 +139,23 @@ func TestUnixFSSelectorCopy(t *testing.T) {
 	pbLinkBuilder := clink.LinkBuilder()
 
 	// get a raw link builder
-	links, err := primeNd.LookupString("Links")
+	links, err := primeNd.LookupByString("Links")
 	Wish(t, err, ShouldEqual, nil)
-	link, err := links.LookupIndex(0)
+	link, err := links.LookupByIndex(0)
 	Wish(t, err, ShouldEqual, nil)
-	rawLink, err := link.LookupString("Hash")
+	rawLink, err := link.LookupByString("Hash")
 	Wish(t, err, ShouldEqual, nil)
 	rawLinkLink, err := rawLink.AsLink()
 	Wish(t, err, ShouldEqual, nil)
 	rawLinkBuilder := rawLinkLink.LinkBuilder()
 
 	// setup a node builder chooser with DagPB + Raw support
-	var defaultChooser traversal.LinkTargetNodeStyleChooser = dagpb.AddDagPBSupportToChooser(func(ipld.Link, ipld.LinkContext) (ipld.NodeStyle, error) {
-		return basicnode.Style.Any, nil
+	var defaultChooser traversal.LinkTargetNodePrototypeChooser = dagpb.AddDagPBSupportToChooser(func(ipld.Link, ipld.LinkContext) (ipld.NodePrototype, error) {
+		return basicnode.Prototype.Any, nil
 	})
 
 	// create a selector for the whole UnixFS dag
-	ssb := builder.NewSelectorSpecBuilder(basicnode.Style.Any)
+	ssb := builder.NewSelectorSpecBuilder(basicnode.Prototype.Any)
 
 	allSelector, err := ssb.ExploreRecursive(selector.RecursionLimitNone(),
 		ssb.ExploreAll(ssb.ExploreRecursiveEdge())).Selector()
@@ -164,8 +164,8 @@ func TestUnixFSSelectorCopy(t *testing.T) {
 	// execute the traversal
 	err = traversal.Progress{
 		Cfg: &traversal.Config{
-			LinkLoader:                 loader,
-			LinkTargetNodeStyleChooser: defaultChooser,
+			LinkLoader:                     loader,
+			LinkTargetNodePrototypeChooser: defaultChooser,
 		},
 	}.WalkAdv(primeNd, allSelector, func(pg traversal.Progress, nd ipld.Node, r traversal.VisitReason) error {
 		// for each node encountered, check if it's a DabPB Node or a Raw Node and if so


### PR DESCRIPTION
Propagating some updates to go-ipld-prime interfaces and exported symbols through this repo.

One commit for each of the version jumps: one for v0.4.0, and one for v0.5.0.  See commit messages for details.

Externally apparently semantics should be more or less unchanged.